### PR TITLE
Fix link to changelog

### DIFF
--- a/QTalsim/metadata.txt
+++ b/QTalsim/metadata.txt
@@ -16,7 +16,7 @@ license=GPL-3.0
 # Recommended items:
 
 hasProcessingProvider=no
-changelog=https://github.com/sydroconsult/QTalsim/main/CHANGELOG.md
+changelog=https://github.com/sydroconsult/QTalsim/blob/main/QTalsim/CHANGELOG.md
 
 # Tags are comma separated with spaces allowed
 tags=python, talsim, hydrological-modelling


### PR DESCRIPTION
I think this should fix the link to the changelog which is displayed in the QGIS Python Plugins Repository